### PR TITLE
Extend @available to support PackageDescription

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -616,6 +616,10 @@ enum class PlatformAgnosticAvailabilityKind {
   /// The declaration is available in some but not all versions
   /// of Swift, as specified by the VersionTuple members.
   SwiftVersionSpecific,
+  /// The declaration is available in some but not all versions
+  /// of SwiftPM's PackageDescription library, as specified by
+  /// the VersionTuple members.
+  SwiftPMManifestVersionSpecific,
   /// The declaration is unavailable for other reasons.
   Unavailable,
 };
@@ -686,6 +690,9 @@ public:
   /// Whether this is a language-version-specific entity.
   bool isLanguageVersionSpecific() const;
 
+  /// Whether this is a SwiftPM manifest version specific entity.
+  bool isSwiftPMManifestVersionSpecific() const;
+
   /// Whether this is an unconditionally unavailable entity.
   bool isUnconditionallyUnavailable() const;
 
@@ -721,6 +728,12 @@ public:
 
   /// Returns true if this attribute is active given the current platform.
   bool isActivePlatform(const ASTContext &ctx) const;
+
+  /// Returns the minimum version from the AST context corresponding to
+  /// the available kind. For e.g., this will return the effective language
+  /// version for swift version-specific availability kind, swiftpm manifest
+  /// version for manifest-specific availability.
+  llvm::VersionTuple getAvailKindMinVersion(const ASTContext &ctx) const;
 
   /// Compare this attribute's version information against the platform or
   /// language version (assuming the this attribute pertains to the active

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -37,6 +37,9 @@ enum class AvailabilitySpecKind {
 
     /// A language-version constraint of the form "swift X.Y.Z"
     LanguageVersionConstraint,
+
+    /// A swiftpm-manifest-version constraint of the form "_PackageDescription X.Y.Z"
+    SwiftPMManifestVersionConstraint,
 };
 
 /// The root class for specifications of API availability in availability
@@ -133,6 +136,43 @@ public:
   void *
   operator new(size_t Bytes, ASTContext &C,
                unsigned Alignment = alignof(LanguageVersionConstraintAvailabilitySpec)){
+    return AvailabilitySpec::operator new(Bytes, C, Alignment);
+  }
+};
+
+/// \brief An availability specification that guards execution based on the
+/// compile-time swiftpm manifest version, e.g., swiftpm-manifest-version >= 3.0.1.
+class SwiftPMManifestVersionConstraintAvailabilitySpec : public AvailabilitySpec {
+  SourceLoc PackageDescriptionLoc;
+
+  llvm::VersionTuple Version;
+  SourceRange VersionSrcRange;
+
+public:
+  SwiftPMManifestVersionConstraintAvailabilitySpec(SourceLoc PackageDescriptionLoc,
+                                            llvm::VersionTuple Version,
+                                            SourceRange VersionSrcRange)
+    : AvailabilitySpec(AvailabilitySpecKind::SwiftPMManifestVersionConstraint),
+      PackageDescriptionLoc(PackageDescriptionLoc), Version(Version),
+      VersionSrcRange(VersionSrcRange) {}
+
+  SourceLoc getPackageDescriptionLoc() const { return PackageDescriptionLoc; }
+
+  // The swiftpm manifest version to compare against.
+  llvm::VersionTuple getVersion() const { return Version; }
+  SourceRange getVersionSrcRange() const { return VersionSrcRange; }
+
+  SourceRange getSourceRange() const;
+
+  void print(raw_ostream &OS, unsigned Indent) const;
+
+  static bool classof(const AvailabilitySpec *Spec) {
+    return Spec->getKind() == AvailabilitySpecKind::SwiftPMManifestVersionConstraint;
+  }
+
+  void *
+  operator new(size_t Bytes, ASTContext &C,
+               unsigned Alignment = alignof(SwiftPMManifestVersionConstraintAvailabilitySpec)){
     return AvailabilitySpec::operator new(Bytes, C, Alignment);
   }
 };

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1365,15 +1365,15 @@ ERROR(attr_availability_expected_equal,none,
 ERROR(attr_availability_expected_version,none,
       "expected version number in '%0' attribute", (StringRef))
 
-WARNING(attr_availability_swift_expected_option,none,
+WARNING(attr_availability_platform_agnostic_expected_option,none,
       "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
-      "for platform 'swift'", (StringRef))
-WARNING(attr_availability_swift_expected_deprecated_version,none,
+      "for platform '%1'", (StringRef, StringRef))
+WARNING(attr_availability_platform_agnostic_expected_deprecated_version,none,
       "expected version number with 'deprecated' in '%0' attribute for "
-      "platform 'swift'", (StringRef))
-WARNING(attr_availability_swift_infeasible_option,none,
-      "'%0' cannot be used in '%1' attribute for platform 'swift'",
-      (StringRef, StringRef))
+      "platform '%1'", (StringRef, StringRef))
+WARNING(attr_availability_platform_agnostic_infeasible_option,none,
+      "'%0' cannot be used in '%1' attribute for platform '%2'",
+      (StringRef, StringRef, StringRef))
 
 WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
       "unexpected version number in '%0' attribute for non-specific platform "
@@ -1608,11 +1608,14 @@ ERROR(avail_query_version_comparison_not_needed,
 ERROR(availability_query_wildcard_required, none,
       "must handle potential future platforms with '*'", ())
 
-ERROR(availability_swift_must_occur_alone, none,
-      "'swift' version-availability must be specified alone", ())
+ERROR(availability_must_occur_alone, none,
+      "'%0' version-availability must be specified alone", (StringRef))
 
 ERROR(pound_available_swift_not_allowed, none,
       "Swift language version checks not allowed in #available(...)", ())
+
+ERROR(pound_available_swiftpm_not_allowed, none,
+      "PackageDescription version checks not allowed in #available(...)", ())
 
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3983,9 +3983,9 @@ NOTE(availability_marked_unavailable, none,
      "%select{getter for |setter for |}0%1 has been explicitly marked "
      "unavailable here", (unsigned, DeclName))
 
-NOTE(availability_introduced_in_swift, none,
-     "%select{getter for |setter for |}0%1 was introduced in Swift %2",
-     (unsigned, DeclName, llvm::VersionTuple))
+NOTE(availability_introduced_in_version, none,
+     "%select{getter for |setter for |}0%1 was introduced in %2 %3",
+     (unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_obsoleted, none,
      "%select{getter for |setter for |}0%1 was obsoleted in %2 %3",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -82,6 +82,9 @@ namespace swift {
     /// \brief User-overridable language version to compile for.
     version::Version EffectiveLanguageVersion = version::Version::getCurrentLanguageVersion();
 
+    /// \brief SwiftPM manifest version to compile for.
+    version::Version SwiftPMManifestVersion;
+
     /// \brief Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -172,6 +172,11 @@ def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, Par
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
+def swiftpm_manifest_version : Separate<["-"], "swiftpm-manifest-version">,
+  Flags<[FrontendOption, HelpHidden, ParseableInterfaceOption]>,
+  HelpText<"Interpret input according to a specific SwiftPM manifest version number">,
+  MetaVarName<"<vers>">;
+
 def tools_directory : Separate<["-"], "tools-directory">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
          ArgumentIsPath]>,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1416,6 +1416,8 @@ public:
   parsePlatformVersionConstraintSpec();
   ParserResult<LanguageVersionConstraintAvailabilitySpec>
   parseLanguageVersionConstraintSpec();
+  ParserResult<SwiftPMManifestVersionConstraintAvailabilitySpec>
+  parseSwiftPMManifestVersionConstraintSpec();
 
   bool canDelayMemberDeclParsing();
 };

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1545,12 +1545,11 @@ namespace decls_block {
   using AvailableDeclAttrLayout = BCRecordLayout<
     Available_DECL_ATTR,
     BCFixed<1>, // implicit flag
-    BCFixed<1>, // is unconditionally unavailable?
-    BCFixed<1>, // is unconditionally deprecated?
     BC_AVAIL_TUPLE, // Introduced
     BC_AVAIL_TUPLE, // Deprecated
     BC_AVAIL_TUPLE, // Obsoleted
     BCVBR<5>,   // platform
+    BCVBR<5>,   // platform agnostic kind
     BCVBR<5>,   // number of bytes in message string
     BCVBR<5>,   // number of bytes in rename string
     BCBlob      // platform, followed by message

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1439,6 +1439,9 @@ public:
         case AvailabilitySpecKind::LanguageVersionConstraint:
           cast<LanguageVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
           break;
+        case AvailabilitySpecKind::SwiftPMManifestVersionConstraint:
+          cast<SwiftPMManifestVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
+          break;
         case AvailabilitySpecKind::OtherPlatform:
           cast<OtherPlatformAvailabilitySpec>(Query)->print(OS, Indent + 2);
           break;

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -28,6 +28,9 @@ SourceRange AvailabilitySpec::getSourceRange() const {
  case AvailabilitySpecKind::LanguageVersionConstraint:
    return cast<LanguageVersionConstraintAvailabilitySpec>(this)->getSourceRange();
 
+ case AvailabilitySpecKind::SwiftPMManifestVersionConstraint:
+   return cast<SwiftPMManifestVersionConstraintAvailabilitySpec>(this)->getSourceRange();
+
   case AvailabilitySpecKind::OtherPlatform:
     return cast<OtherPlatformAvailabilitySpec>(this)->getSourceRange();
   }
@@ -61,6 +64,17 @@ SourceRange LanguageVersionConstraintAvailabilitySpec::getSourceRange() const {
 void LanguageVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
                                                       unsigned Indent) const {
   OS.indent(Indent) << '(' << "language_version_constraint_availability_spec"
+                    << " version='" << getVersion() << "'"
+                    << ')';
+}
+
+SourceRange SwiftPMManifestVersionConstraintAvailabilitySpec::getSourceRange() const {
+  return SourceRange(PackageDescriptionLoc, VersionSrcRange.End);
+}
+
+void SwiftPMManifestVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
+                                                      unsigned Indent) const {
+  OS.indent(Indent) << '(' << "swiftpm_manifest_version_constraint_availability_spec"
                     << " version='" << getVersion() << "'"
                     << ')';
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -221,6 +221,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_AssumeSingleThreaded);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_dependencies);
+  inputArgs.AddLastArg(arguments, options::OPT_swiftpm_manifest_version);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -199,6 +199,16 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       diagnoseSwiftVersion(vers, A, Args, Diags);
   }
 
+  if (auto A = Args.getLastArg(OPT_swiftpm_manifest_version)) {
+    auto vers = version::Version::parseVersionString(
+      A->getValue(), SourceLoc(), &Diags);
+    if (vers.hasValue()) {
+      Opts.SwiftPMManifestVersion = vers.getValue();
+    } else {
+        return true;
+    }
+  }
+
   Opts.AttachCommentsToDecls |= Args.hasArg(OPT_dump_api_path);
 
   Opts.UseMalloc |= Args.hasArg(OPT_use_malloc);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2177,6 +2177,7 @@ bool swift::diagnoseExplicitUnavailability(
   case PlatformAgnosticAvailabilityKind::None:
   case PlatformAgnosticAvailabilityKind::Unavailable:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::SwiftPMManifestVersionSpecific:
   case PlatformAgnosticAvailabilityKind::UnavailableInSwift: {
     bool inSwift = (Attr->getPlatformAgnosticAvailability() ==
                     PlatformAgnosticAvailabilityKind::UnavailableInSwift);
@@ -2235,10 +2236,13 @@ bool swift::diagnoseExplicitUnavailability(
     llvm_unreachable("These aren't considered unavailable");
 
   case AvailableVersionComparison::Unavailable:
-    if (Attr->isLanguageVersionSpecific()
+    if ((Attr->isLanguageVersionSpecific() || Attr->isSwiftPMManifestVersionSpecific())
         && Attr->Introduced.hasValue())
-      diags.diagnose(D, diag::availability_introduced_in_swift,
-                     RawAccessorKind, Name, *Attr->Introduced)
+      diags.diagnose(D, diag::availability_introduced_in_version,
+                     RawAccessorKind, Name,
+                     (Attr->isLanguageVersionSpecific() ? 
+                      "Swift" : "PackageDescription"),
+                     *Attr->Introduced)
         .highlight(Attr->getRange());
     else
       diags.diagnose(D, diag::availability_marked_unavailable, RawAccessorKind,
@@ -2249,10 +2253,19 @@ bool swift::diagnoseExplicitUnavailability(
   case AvailableVersionComparison::Obsoleted:
     // FIXME: Use of the platformString here is non-awesome for application
     // extensions.
+
+    StringRef platformDisplayString;
+    if (Attr->isLanguageVersionSpecific()) {
+        platformDisplayString = "Swift";
+    } else if (Attr->isSwiftPMManifestVersionSpecific()) {
+        platformDisplayString = "PackageDescription";
+    } else {
+        platformDisplayString = Attr->prettyPlatformString();
+    }
+
     diags.diagnose(D, diag::availability_obsoleted,
                    RawAccessorKind, Name,
-                   (Attr->isLanguageVersionSpecific() ?
-                    "Swift" : Attr->prettyPlatformString()),
+                   platformDisplayString,
                    *Attr->Obsoleted)
       .highlight(Attr->getRange());
     break;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2305,12 +2305,11 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
     AvailableDeclAttrLayout::emitRecord(
         Out, ScratchRecord, abbrCode,
         theAttr->isImplicit(),
-        theAttr->isUnconditionallyUnavailable(),
-        theAttr->isUnconditionallyDeprecated(),
         LIST_VER_TUPLE_PIECES(Introduced),
         LIST_VER_TUPLE_PIECES(Deprecated),
         LIST_VER_TUPLE_PIECES(Obsoleted),
         static_cast<unsigned>(theAttr->Platform),
+        static_cast<unsigned>(theAttr->getPlatformAgnosticAvailability()),
         theAttr->Message.size(),
         theAttr->Rename.size(),
         blob);

--- a/test/attr/Inputs/PackageDescription.swift
+++ b/test/attr/Inputs/PackageDescription.swift
@@ -1,0 +1,54 @@
+public enum SwiftVersion {
+    // CHECK: @available(_PackageDescription, introduced: 3.0, deprecated: 4.2, obsoleted: 5.0)
+    @available(_PackageDescription, introduced: 3.0, deprecated: 4.2, obsoleted: 5.0)
+    case v3
+
+    case v4
+
+    // CHECK: @available(_PackageDescription 5.0)
+    // CHECK-NEXT: @available(OSX 10.1, *)
+    // CHECK-NEXT: v5
+    @available(_PackageDescription, introduced: 5.0)
+    @available(macOS, introduced: 10.1)
+    case v5
+}
+
+public class Package {
+
+    public var swiftVersion: [SwiftVersion]
+
+    @available(_PackageDescription 4.3)
+    public var buildSettings: [String: String] {
+        get {
+            return _buildSettings
+        }
+        set {
+            _buildSettings = newValue
+        }
+    }
+    private var _buildSettings: [String: String]
+
+    @available(_PackageDescription 5)
+    public init(
+        swiftVersion: [SwiftVersion] = [],
+        buildSettings: [String: String] = [:]
+    ) {
+        self._buildSettings = buildSettings
+        self.swiftVersion = swiftVersion
+    }
+
+    @available(_PackageDescription, introduced: 3.0, obsoleted: 5.0)
+    public init(
+        swiftVersion: [SwiftVersion] = []
+    ) {
+        self._buildSettings = [:]
+        self.swiftVersion = swiftVersion
+    }
+
+    public func serialize() {
+        for version in swiftVersion {
+            print(version)
+        }
+        print(_buildSettings)
+    }
+}

--- a/test/attr/attr_availability_swiftpm_deserialize.swift
+++ b/test/attr/attr_availability_swiftpm_deserialize.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/PackageDescription.swiftmodule -module-name PackageDescription %S/Inputs/PackageDescription.swift 
+// RUN: not %target-swift-frontend -typecheck -I %t -swiftpm-manifest-version 4.2 %s 2>&1 | %FileCheck -check-prefix FOURTWO %s
+// RUN: not %target-swift-frontend -typecheck -I %t -swiftpm-manifest-version 5 %s 2>&1 | %FileCheck -check-prefix FIVE %s
+// RUN: %target-swift-ide-test -print-module -module-to-print PackageDescription -source-filename x -I %t | %FileCheck %S/Inputs/PackageDescription.swift
+
+import PackageDescription
+
+// FOURTWO: warning: 'v3' is deprecated
+// FOURTWO: error: 'v5' is unavailable
+// FOURTWO: note: 'v5' was introduced in PackageDescription 5.0
+// FIVE: error: 'v3' is unavailable
+// FIVE: note: 'v3' was obsoleted in PackageDescription 5.0
+let package = Package(
+    swiftVersion: [ .v3, .v4, .v5 ]
+)
+
+// FOURTWO: note: 'buildSettings' was introduced in PackageDescription 4.3
+package.buildSettings = ["Foo": "Bar"]

--- a/test/attr/attr_availability_swiftpm_v4.swift
+++ b/test/attr/attr_availability_swiftpm_v4.swift
@@ -1,0 +1,65 @@
+// RUN: %target-typecheck-verify-swift -swiftpm-manifest-version 4.0
+
+@available(_PackageDescription 3)
+func shortThree() {}
+
+@available(_PackageDescription, introduced: 3.0)
+func threePointOh() {}
+
+@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0)
+func threePointOhOnly() {} // expected-note {{was obsoleted in PackageDescription 4.0}}
+
+@available(_PackageDescription, deprecated: 3.0)
+func deprecatedThreePointOh() {}
+
+@available(_PackageDescription, obsoleted: 3.0)
+func obsoletedThreePointOh() {} // expected-note {{was obsoleted in PackageDescription 3.0}}
+
+@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0)
+class ThreePointOhOnly {} // expected-note {{was obsoleted in PackageDescription 4.0}}
+
+@available(_PackageDescription, introduced: 3, obsoleted: 4, message: "use abc")
+class ThreeOnlyWithMessage {} // expected-note {{was obsoleted in PackageDescription 4}}
+
+
+@available(_PackageDescription 4)
+func shortFour() {}
+
+@available(_PackageDescription 4.0)
+func shortFourPointOh() {}
+
+@available(_PackageDescription, introduced: 4)
+func four() {}
+
+@available(_PackageDescription, introduced: 4.0)
+func fourPointOh() {}
+
+@available(_PackageDescription 4)
+class ShortFour {}
+
+shortThree()
+threePointOh()
+threePointOhOnly() // expected-error {{is unavailable}}
+deprecatedThreePointOh() // expected-warning {{is deprecated}}
+obsoletedThreePointOh() // expected-error {{is unavailable}}
+let a : ThreePointOhOnly // expected-error {{is unavailable}}
+let b : ThreeOnlyWithMessage // expected-error {{is unavailable: use abc}}
+
+
+shortFour()
+shortFourPointOh()
+four()
+fourPointOh()
+let aa : ShortFour
+
+@available(_PackageDescription, introduced: 4.0)
+@available(*, deprecated, message: "test deprecated")
+func unconditionallyDeprecated() {}
+
+unconditionallyDeprecated() // expected-warning {{test deprecated}}
+
+@available(_PackageDescription 4.0, iOS 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}}
+func shouldBeAlone() {} 
+
+@available(_PackageDescription 4.0, swift 2.0, *) // expected-error {{'_PackageDescription' version-availability must be specified alone}} // expected-error {{'swift' version-availability must be specified alone}}
+func shouldBeAlone2() {} 


### PR DESCRIPTION
This introduces a new private availability kind "_PackageDescription" to
allow availability testing by an arbitary version that can be passed
using a new command-line flag "-swiftpm-manifest-version". The semantics
are exactly same as Swift version specific availability. In longer term,
it maybe possible to remove this enhancement once there is
a language-level availability support for 3rd party libraries.

Motivation:

Swift packages are configured using a Package.swift manifest file. The
manifest file uses a library called PackageDescription, which contains
various settings that can be configured for a package. The new additions
in the PackageDescription APIs are gated behind a "tools version" that
every manifest must declare. This means, packages don't automatically
get access to the new APIs. They need to update their declared tools
version in order to use the new API. This is basically similar to the
minimum deployment target version we have for our OSes.

This gating is important for allowing packages to maintain backwards
compatibility. SwiftPM currently checks for API usages at runtime in
order to implement this gating. This works reasonably well but can lead
to a poor experience with features like code-completion and module
interface generation in IDEs and editors (that use sourcekit-lsp) as
SwiftPM has no control over these features.